### PR TITLE
Add support for MongoDB Query Operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ MongoDB Query Operators can be used by appending them as a suffix to the field n
 ### Supported Operators
 | MongoDB Query Operator | Field Suffix | Description                                                                                                                                                                     |
 |------------------------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| $eq                    | _eq          | Matches values that are equal to a specified value. <br/> (Usefull for matching exact values if a field is included in allowedRegexFields) <br/> Example:  `/user?name_eq=Alex` |
+| $eq                    | _eq          | Matches values that are equal to a specified value. <br/> (Useful for matching exact values if a field is included in allowedRegexFields) <br/> Example:  `/user?name_eq=Alex` |
 | $gt                    | _gt          | Matches values that are greater than a specified value. <br/> Example:  `/user?createdAt_gt=2022-10-25T00%3A00%3A00.000Z`                                                       |
 | $gte                   | _gte         | Matches values that are greater than or equal to a specified value. <br/> Example:  `/user?createdAt_gte=2022-10-25T00%3A00%3A00.000Z`                                          |
 | $in                    | _in          | Matches any of the values specified in an array. <br/> Example: `/user?name_in=Alex&name_in=Peter`                                                                              |
@@ -82,21 +82,3 @@ MongoDB Query Operators can be used by appending them as a suffix to the field n
 | $lte                   | _lte         | Matches values that are less than or equal to a specified value. <br/> Example:  `/user?createdAt_lte=2022-10-25T00%3A00%3A00.000Z`                                             |
 | $ne                    | _ne          | Matches all values that are not equal to a specified value. <br/> Example:  `/user?name_ne=Alex`                                                                                |
 | $nin                   | _nin         | Matches none of the values specified in an array. <br/> Example:  `/user?name_nin=Alex&name_nin=Peter`                                                                          |
-
-### Example Filter in React Admin
-```js
-import { Datagrid, DateField, DateTimeInput, List, TextField } from 'react-admin';
-
-const userFilter = [
-    <DateTimeInput source="createdAt_gte" alwaysOn />,
-];
-
-export const UserList = () => (
-    <List filters={userFilter}>
-        <Datagrid>
-            <TextField source="name" label="Name" />
-            <DateField source="createdAt" showTime />
-        </Datagrid>
-    </List>
-);
-```

--- a/README.md
+++ b/README.md
@@ -68,3 +68,35 @@ export interface raExpressMongooseOptions<T> {
   ACLMiddleware?: (name: string) => RequestHandler;
 }
 ```
+## Query Operators
+
+MongoDB Query Operators can be used by appending them as a suffix to the field name ([see here](https://marmelab.com/react-admin/FilteringTutorial.html#filter-operators)).
+### Supported Operators
+| MongoDB Query Operator | Field Suffix | Description                                                                                                                                                                     |
+|------------------------|--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| $eq                    | _eq          | Matches values that are equal to a specified value. <br/> (Usefull for matching exact values if a field is included in allowedRegexFields) <br/> Example:  `/user?name_eq=Alex` |
+| $gt                    | _gt          | Matches values that are greater than a specified value. <br/> Example:  `/user?createdAt_gt=2022-10-25T00%3A00%3A00.000Z`                                                       |
+| $gte                   | _gte         | Matches values that are greater than or equal to a specified value. <br/> Example:  `/user?createdAt_gte=2022-10-25T00%3A00%3A00.000Z`                                          |
+| $in                    | _in          | Matches any of the values specified in an array. <br/> Example: `/user?name_in=Alex&name_in=Peter`                                                                              |
+| $lt                    | _lt          | Matches values that are less than a specified value. <br/> Example:  `/user?createdAt_lt=2022-10-25T00%3A00%3A00.000Z`                                                          |
+| $lte                   | _lte         | Matches values that are less than or equal to a specified value. <br/> Example:  `/user?createdAt_lte=2022-10-25T00%3A00%3A00.000Z`                                             |
+| $ne                    | _ne          | Matches all values that are not equal to a specified value. <br/> Example:  `/user?name_ne=Alex`                                                                                |
+| $nin                   | _nin         | Matches none of the values specified in an array. <br/> Example:  `/user?name_nin=Alex&name_nin=Peter`                                                                          |
+
+### Example Filter in React Admin
+```js
+import { Datagrid, DateField, DateTimeInput, List, TextField } from 'react-admin';
+
+const userFilter = [
+    <DateTimeInput source="createdAt_gte" alwaysOn />,
+];
+
+export const UserList = () => (
+    <List filters={userFilter}>
+        <Datagrid>
+            <TextField source="name" label="Name" />
+            <DateField source="createdAt" showTime />
+        </Datagrid>
+    </List>
+);
+```

--- a/src/utils/castFilter.ts
+++ b/src/utils/castFilter.ts
@@ -48,7 +48,9 @@ export default function castFilter<T extends ADPBaseModel>(
           obj[field].$gte = obj[key];
           break;
         case "in":
-          obj[field].$in = parsePossibleObjectId(obj[key]);
+          obj[field].$in = Array.isArray(obj[key])
+            ? obj[key].map((item) => parsePossibleObjectId(item))
+            : [parsePossibleObjectId(obj[key])];
           break;
         case "lt":
           obj[field].$lt = obj[key];
@@ -60,7 +62,9 @@ export default function castFilter<T extends ADPBaseModel>(
           obj[field].$ne = obj[key];
           break;
         case "nin":
-          obj[field].$nin = parsePossibleObjectId(obj[key]);
+          obj[field].$in = Array.isArray(obj[key])
+            ? obj[key].map((item) => parsePossibleObjectId(item))
+            : [parsePossibleObjectId(obj[key])];
           break;
       }
       delete obj[key];

--- a/src/utils/castFilter.ts
+++ b/src/utils/castFilter.ts
@@ -17,7 +17,47 @@ export default function castFilter<T extends ADPBaseModel>(
       obj[key] = path(key).cast(obj[key], null, null);
     } catch (e) {}
 
-    if (allowedRegexes.includes(key) && typeof obj[key] === "string") {
+    /**  Parse MongoDB Query Operators **/
+    let splittedKey = key.split("_");
+    if (
+      splittedKey.length > 1 &&
+      ["eq", "gt", "gte", "in", "lt", "lte", "ne", "nin"].includes(
+        splittedKey[splittedKey.length - 1]
+      )
+    ) {
+      let operator = splittedKey.pop();
+      let field = splittedKey.join("_");
+
+      obj[field] =
+        obj[field] && typeof obj[field] == "object" ? obj[field] : {};
+      switch (operator) {
+        case "eq":
+          obj[field].$eq = obj[key];
+          break;
+        case "gt":
+          obj[field].$gt = obj[key];
+          break;
+        case "gte":
+          obj[field].$gte = obj[key];
+          break;
+        case "in":
+          obj[field].$in = obj[key];
+          break;
+        case "lt":
+          obj[field].$lt = obj[key];
+          break;
+        case "lte":
+          obj[field].$lte = obj[key];
+          break;
+        case "ne":
+          obj[field].$ne = obj[key];
+          break;
+        case "nin":
+          obj[field].$nin = obj[key];
+          break;
+      }
+      delete obj[key];
+    } else if (allowedRegexes.includes(key) && typeof obj[key] === "string") {
       obj[key] = new RegExp(escapeStringRegexp(obj[key]));
     }
   });


### PR DESCRIPTION
Add support For MongoDB Query Operators as described in the [react-admin documentation](https://marmelab.com/react-admin/FilteringTutorial.html#filter-operators).
